### PR TITLE
remove 'ForegroundColor' from Write-Error because it is invalid.

### DIFF
--- a/init.ps1
+++ b/init.ps1
@@ -76,7 +76,7 @@ try {
     & $mkcert "*.sc.localhost"
 }
 catch {
-    Write-Error "An error occurred while attempting to generate TLS certificate: $_" -ForegroundColor Red
+    Write-Error "An error occurred while attempting to generate TLS certificate: $_"
 }
 finally {
     Pop-Location


### PR DESCRIPTION
Fix for possible error:
Downloading and installing mkcert certificate tool...
Generating Traefik TLS certificate...
C:\Projects\MVP-Site\init.ps1 : A parameter cannot be found that matches parameter name 'ForegroundColor'.
    + CategoryInfo          : InvalidArgument: (:) [init.ps1], ParameterBindingException
    + FullyQualifiedErrorId : NamedParameterNotFound,init.ps1

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (non-breaking change; modified files are limited to the `/docs` directory)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the Contributing guide.
- [ ] My code follows the code style of this project.
- [ ] My code/comments/docs fully adhere to the Code of Conduct.
- [ ] My change is a code change and it requires an update to the documentation.
- [ ] My change is a documentation change and it requires an update to the navigation.
