### PR TITLE
Removed creation of k8s dashboard as no longer supported

### DIFF
--- a/k8s/CreateAKS.ps1
+++ b/k8s/CreateAKS.ps1
@@ -38,7 +38,7 @@ az aks create --resource-group $ResourceGroup `
     --node-count 1 `
     --generate-ssh-keys `
     --network-plugin azure `
-    --enable-addons monitoring,kube-dashboard `
+    --enable-addons monitoring `
     --node-resource-group "$($ResourceGroup)_AKS_BackEnd"
 Write-Host "--- Complete: AKS Created ---" -ForegroundColor Green
 


### PR DESCRIPTION
To address [Issue 10](https://github.com/Sitecore/MVP-Site/issues/10).

## Description
Removed K8s dashboard module from AKS creation command

## Motivation
AKS no longer supports K8s dashboard > 1.19.0