### PR TITLE
Fix to Dockerfile build script

### DIFF
--- a/docker/build/dotnetsdk/Dockerfile
+++ b/docker/build/dotnetsdk/Dockerfile
@@ -11,6 +11,8 @@ ARG NETCORE_BUILD_IMAGE
 FROM ${NETCORE_BUILD_IMAGE} as netcore-sdk
 FROM ${BUILD_IMAGE}
 
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
 # Ensure updated nuget. Depending on your Windows version, dotnet/framework/sdk:4.8 tag may provide an outdated client.
 # See https://github.com/microsoft/dotnet-framework-docker/blob/1c3dd6638c6b827b81ffb13386b924f6dcdee533/4.8/sdk/windowsservercore-ltsc2019/Dockerfile#L7
 ENV NUGET_VERSION 5.6.0

--- a/docker/build/solution/Dockerfile
+++ b/docker/build/solution/Dockerfile
@@ -8,6 +8,7 @@ ARG BASE_IMAGE
 ARG BUILD_IMAGE
 
 FROM ${BUILD_IMAGE} AS nuget-prep
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 # Gather only artifacts necessary for NuGet restore, retaining directory structure
 COPY *.sln nuget.config /nuget/
 COPY src/ /temp/


### PR DESCRIPTION
## Description
When running the docker builds it will fail on 2 or 3 steps in 2 different Dockerfiles because it tries to run a PowerShell command in a CMD context. This change makes sure the build uses PowerShell as default to run these commands

## Motivation
The docker images couldn't be build because of some RUN commands running in CMD instead of PowerShell. This happened on two different machines independently from each other.
Adding these SHELL settings fixes the issue by making sure RUN commands are performed in PowerShell.