### PR TITLE
K8s bake all deploys

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -120,7 +120,7 @@ stages:
               enableTelemetry: false
           - task: KubernetesManifest@0
             displayName: Bake Secrets
-            name: 'bake'
+            name: 'bake secrets'
             inputs:
               action: 'bake'
               renderType: 'kustomize'
@@ -134,7 +134,7 @@ stages:
               manifests: '$(bake.manifestsBundle)'
           - task: KubernetesManifest@0
             displayName: Bake Ingress Specifications
-            name: 'bake'
+            name: 'bake ingress'
             inputs:
               action: 'bake'
               renderType: 'kustomize'
@@ -153,7 +153,7 @@ stages:
               outputFormat: ''
           - task: KubernetesManifest@0
             displayName: Bake External Specifications
-            name: 'bake'
+            name: 'bake external'
             inputs:
               action: 'bake'
               renderType: 'kustomize'
@@ -172,7 +172,7 @@ stages:
               outputFormat: ''
           - task: KubernetesManifest@0
             displayName: Bake Init Specifications
-            name: 'bake'
+            name: 'bake init'
             inputs:
               action: 'bake'
               renderType: 'kustomize'
@@ -191,7 +191,7 @@ stages:
               outputFormat: ''
           - task: KubernetesManifest@0
             displayName: Bake Application Specifications
-            name: 'bake'
+            name: 'bake application'
             inputs:
               action: 'bake'
               renderType: 'kustomize'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -120,7 +120,7 @@ stages:
               enableTelemetry: false
           - task: KubernetesManifest@0
             displayName: Bake Secrets
-            name: 'bake secrets'
+            name: 'bake_secrets'
             inputs:
               action: 'bake'
               renderType: 'kustomize'
@@ -134,7 +134,7 @@ stages:
               manifests: '$(bake.manifestsBundle)'
           - task: KubernetesManifest@0
             displayName: Bake Ingress Specifications
-            name: 'bake ingress'
+            name: 'bake_ingress'
             inputs:
               action: 'bake'
               renderType: 'kustomize'
@@ -153,7 +153,7 @@ stages:
               outputFormat: ''
           - task: KubernetesManifest@0
             displayName: Bake External Specifications
-            name: 'bake external'
+            name: 'bake_external'
             inputs:
               action: 'bake'
               renderType: 'kustomize'
@@ -172,7 +172,7 @@ stages:
               outputFormat: ''
           - task: KubernetesManifest@0
             displayName: Bake Init Specifications
-            name: 'bake init'
+            name: 'bake_init'
             inputs:
               action: 'bake'
               renderType: 'kustomize'
@@ -191,7 +191,7 @@ stages:
               outputFormat: ''
           - task: KubernetesManifest@0
             displayName: Bake Application Specifications
-            name: 'bake application'
+            name: 'bake_application'
             inputs:
               action: 'bake'
               renderType: 'kustomize'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -119,21 +119,28 @@ stages:
               useLegacyPattern: false
               enableTelemetry: false
           - task: KubernetesManifest@0
-            displayName: Bake K8s Secrets
+            displayName: Bake Secrets
             name: 'bake'
             inputs:
               action: 'bake'
               renderType: 'kustomize'
               kustomizationPath: '$(System.ArtifactsDirectory)/k8s-specs/secrets/'
           - task: KubernetesManifest@0
-            displayName: Deploy K8s Secrets
+            displayName: Deploy Secrets
             inputs:
               action: 'deploy'
               kubernetesServiceConnection: '$(AKS_SERVICE_ENDPOINT)'
               namespace: 'mvp-staging'
               manifests: '$(bake.manifestsBundle)'
+          - task: KubernetesManifest@0
+            displayName: Bake Ingress Specifications
+            name: 'bake'
+            inputs:
+              action: 'bake'
+              renderType: 'kustomize'
+              kustomizationPath: '$(System.ArtifactsDirectory)/k8s-specs/ingress-nginx/'
           - task: Kubernetes@1
-            displayName: Deploy Ingress Specification
+            displayName: Deploy Ingress Specifications
             inputs:
               connectionType: 'Kubernetes Service Connection'
               kubernetesServiceEndpoint: '$(AKS_SERVICE_ENDPOINT)'
@@ -144,6 +151,13 @@ stages:
               secretType: 'dockerRegistry'
               containerRegistryType: 'Azure Container Registry'
               outputFormat: ''
+          - task: KubernetesManifest@0
+            displayName: Bake External Specifications
+            name: 'bake'
+            inputs:
+              action: 'bake'
+              renderType: 'kustomize'
+              kustomizationPath: '$(System.ArtifactsDirectory)/k8s-specs/external/'
           - task: Kubernetes@1
             displayName: Deploy External Specifications
             inputs:
@@ -156,6 +170,13 @@ stages:
               secretType: 'dockerRegistry'
               containerRegistryType: 'Azure Container Registry'
               outputFormat: ''
+          - task: KubernetesManifest@0
+            displayName: Bake Init Specifications
+            name: 'bake'
+            inputs:
+              action: 'bake'
+              renderType: 'kustomize'
+              kustomizationPath: '$(System.ArtifactsDirectory)/k8s-specs/init/'
           - task: Kubernetes@1
             displayName: Deploy Init Specifications
             inputs:
@@ -168,6 +189,13 @@ stages:
               secretType: 'dockerRegistry'
               containerRegistryType: 'Azure Container Registry'
               outputFormat: ''
+          - task: KubernetesManifest@0
+            displayName: Bake Application Specifications
+            name: 'bake'
+            inputs:
+              action: 'bake'
+              renderType: 'kustomize'
+              kustomizationPath: '$(System.ArtifactsDirectory)/k8s-specs'
           - task: Kubernetes@1
             displayName: Deploy Application Specifications
             inputs:


### PR DESCRIPTION
With the move to 10.1 all specs now require baking before deployment.