### PR TITLE
Changed k8s to use mssql windows image

### DIFF
--- a/k8s/specs/external/kustomization.yaml
+++ b/k8s/specs/external/kustomization.yaml
@@ -3,8 +3,8 @@ kind: Kustomization
 
 images:
 - name: mssql
-  newName: mcr.microsoft.com/mssql/server
-  newTag: 2017-CU21-ubuntu-16.04
+  newName: scr.sitecore.com/sxp/sitecore-xm1-mssql
+  newTag: 10.1-ltsc2019
 - name: solr
   newName: solr
   newTag: 8.4.0

--- a/k8s/specs/external/mssql.yaml
+++ b/k8s/specs/external/mssql.yaml
@@ -26,15 +26,10 @@ spec:
         app: mssql
     spec:
       nodeSelector:
-        kubernetes.io/os: linux
+        kubernetes.io/os: windows
       containers:
       - name: mssql
         image: mssql
-        securityContext:
-          allowPrivilegeEscalation: false
-          readOnlyRootFilesystem: true
-          runAsNonRoot: true
-          runAsUser: 101
         ports:
         - containerPort: 1433
         env:
@@ -45,16 +40,10 @@ spec:
               key: sitecore-databasepassword.txt
         - name: ACCEPT_EULA
           value: "Y"
-        volumeMounts:
-          - mountPath: /var/opt/mssql
-            name: sql
-        resources:
-          requests:
-            memory: 2Gi
-            cpu: 200m
-          limits:
-            memory: 3Gi
-            cpu: 700m    
-      volumes:
-        - name: sql
-          emptyDir: {}
+        - name: SITECORE_ADMIN_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: sitecore-admin
+              key: sitecore-adminpassword.txt  
+      imagePullSecrets:
+      - name: regcred 


### PR DESCRIPTION
Changes k8s to use windows based mssql image, as the init container woudn't run against linux sql container.