### PR TITLE
Added allowedPushOperations to all content modules

### DIFF
--- a/src/Feature/Navigation/Navigation.module.json
+++ b/src/Feature/Navigation/Navigation.module.json
@@ -4,15 +4,18 @@
     "includes": [
       {
         "name": "templates",
-        "path": "/sitecore/templates/Feature/Navigation"
+        "path": "/sitecore/templates/Feature/Navigation",
+        "allowedPushOperations": "CreateUpdateAndDelete"
       },
       {
         "name": "layouts",
-        "path": "/sitecore/layout/Renderings/Feature/Navigation"
+        "path": "/sitecore/layout/Renderings/Feature/Navigation",
+        "allowedPushOperations": "CreateUpdateAndDelete"
       },
       {
         "name": "Content Resolvers",
-        "path": "/sitecore/system/Modules/Layout Service/Rendering Contents Resolvers/Navigation"
+        "path": "/sitecore/system/Modules/Layout Service/Rendering Contents Resolvers/Navigation",
+        "allowedPushOperations": "CreateUpdateAndDelete"
       }
     ]
   }

--- a/src/Foundation/Multisite/Multisite.module.json
+++ b/src/Foundation/Multisite/Multisite.module.json
@@ -4,7 +4,8 @@
         "includes": [
             {
                 "name": "templates",
-                "path": "/sitecore/templates/Foundation/Multisite"
+                "path": "/sitecore/templates/Foundation/Multisite",
+                "allowedPushOperations": "CreateUpdateAndDelete"
             }
         ]
     }

--- a/src/Project/MvpSite/MvpSite.module.json
+++ b/src/Project/MvpSite/MvpSite.module.json
@@ -4,39 +4,48 @@
     "includes": [
       {
         "name": "layouts",
-        "path": "/sitecore/layout/Layouts/Project/MvpSite"
+        "path": "/sitecore/layout/Layouts/Project/MvpSite",
+        "allowedPushOperations": "CreateUpdateAndDelete"
       },
       {
         "name": "placeholders",
-        "path": "/sitecore/layout/Placeholder Settings/Project/MvpSite"
+        "path": "/sitecore/layout/Placeholder Settings/Project/MvpSite",
+        "allowedPushOperations": "CreateUpdateAndDelete"
       },
       {
         "name": "media",
-        "path": "/sitecore/media library/MvpSite"
+        "path": "/sitecore/media library/MvpSite",
+        "allowedPushOperations": "CreateOnly"
       },
       {
         "name": "forms",
-        "path": "/sitecore/Forms/MvpSite"
+        "path": "/sitecore/Forms/MvpSite",
+        "allowedPushOperations": "CreateOnly"
       },
       {
         "name": "dictionary",
-        "path": "/sitecore/system/Dictionary/MvpSite"
+        "path": "/sitecore/system/Dictionary/MvpSite",
+        "allowedPushOperations": "CreateOnly"
       },
       {
         "name": "templates",
-        "path": "/sitecore/templates/Project/MvpSite"
+        "path": "/sitecore/templates/Project/MvpSite",
+        "allowedPushOperations": "CreateUpdateAndDelete"
       },
       {
         "name": "branche-templates",
-        "path": "/sitecore/templates/Branches/Project/MvpSite"
+        "path": "/sitecore/templates/Branches/Project/MvpSite",
+        "allowedPushOperations": "CreateUpdateAndDelete"
       },
       {
         "name": "content",
-        "path": "/sitecore/content/MvpSite"
+        "path": "/sitecore/content/MvpSite",
+        "allowedPushOperations": "CreateOnly"
       },
       {
         "name": "apikey",
-        "path": "/sitecore/system/Settings/Services/API Keys/MvpSite"
+        "path": "/sitecore/system/Settings/Services/API Keys/MvpSite",
+        "allowedPushOperations": "CreateUpdateAndDelete"
       }
     ]
   }


### PR DESCRIPTION
Ensured allowedPushOperations existed all synced content items.

This means we can content edit without worry of future deployment blowing away the changes.