### PR TITLE
Fixed issue with sql-init not initializing admin password

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -84,6 +84,7 @@ services:
       SQL_SERVER: mssql
       SQL_ADMIN_LOGIN: sa
       SQL_ADMIN_PASSWORD: ${SQL_SA_PASSWORD}
+      sitecore_admin_password: ${SITECORE_ADMIN_PASSWORD}
     depends_on:
       mssql:
         condition: service_healthy
@@ -125,6 +126,8 @@ services:
     depends_on:
       solutionBuildOutput:
         condition: service_started
+      mssql-init:
+        condition: service_completed_successfully
     volumes:
       - ${LOCAL_DEPLOY_PATH}\sitecore:C:\deploy
       - ${LOCAL_DATA_PATH}\cd:C:\inetpub\wwwroot\App_Data\logs
@@ -155,6 +158,8 @@ services:
     depends_on:
       solutionBuildOutput:
         condition: service_started
+      mssql-init:
+        condition: service_completed_successfully    
     volumes:
       - ${LOCAL_DEPLOY_PATH}\sitecore:C:\deploy
       - ${LOCAL_DATA_PATH}\cm:C:\inetpub\wwwroot\App_Data\logs

--- a/docker/build/mssql-init/Dockerfile
+++ b/docker/build/mssql-init/Dockerfile
@@ -11,5 +11,3 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 
 COPY --from=headless_services_resources C:\module\db c:\resources\headless_services_data
 COPY --from=spe_resources C:\module\db c:\resources\spe_data
-
-ENTRYPOINT .\DeployDatabases.ps1 -ResourcesDirectory c:\resources -SqlServer $env:SQL_SERVER -SqlAdminUser $env:SQL_ADMIN_LOGIN -SqlAdminPassword $env:SQL_ADMIN_PASSWORD -SkipStartingServer


### PR DESCRIPTION
Fixed issue with MSSQL Init container not executing steps to set admin password

Changed docker-compose to add dependency between CM,CD & MSSQL-Init, ensuring DB's are initialised before starting application instances.