### PR TITLE
Azure devops changes

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -161,20 +161,6 @@ stages:
               namespace: 'mvp-staging'
               manifests: '$(bake_external.manifestsBundle)'
           - task: KubernetesManifest@0
-            displayName: Delete Previous MSSQL-Init Job
-            inputs:
-              action: 'delete'
-              kubernetesServiceConnection: '$(AKS_SERVICE_ENDPOINT)'
-              namespace: 'mvp-staging'
-              arguments: 'job mssql-init'
-          - task: KubernetesManifest@0
-            displayName: Delete Previous Solr-Init Job
-            inputs:
-              action: 'delete'
-              kubernetesServiceConnection: '$(AKS_SERVICE_ENDPOINT)'
-              namespace: 'mvp-staging'
-              arguments: 'job solr-init'
-          - task: KubernetesManifest@0
             displayName: Bake Init Specifications
             name: 'bake_init'
             inputs:

--- a/k8s/specs/ingress-nginx/ingress.yaml
+++ b/k8s/specs/ingress-nginx/ingress.yaml
@@ -41,7 +41,7 @@ spec:
       paths:
       - path: /
         backend:
-          serviceName: rendering
+          serviceName: mvp-rendering
           servicePort: 80
 
   tls:

--- a/k8s/specs/kustomization.yaml
+++ b/k8s/specs/kustomization.yaml
@@ -17,4 +17,4 @@ resources:
 - cm.yaml
 - cd.yaml
 - id.yaml
-- rendering.yaml
+- mvp-rendering.yaml

--- a/k8s/specs/mvp-rendering.yaml
+++ b/k8s/specs/mvp-rendering.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: rendering
+  name: mvp-rendering
 spec:
   selector:
-    app: rendering
+    app: mvp-rendering
   ports:
   - protocol: TCP
     port: 80
@@ -12,18 +12,18 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: rendering
+  name: mvp-rendering
   labels:
-    app: rendering
+    app: mvp-rendering
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: rendering
+      app: mvp-rendering
   template:
     metadata:
       labels:
-        app: rendering
+        app: mvp-rendering
     spec:
       nodeSelector:
         kubernetes.io/os: windows
@@ -41,7 +41,7 @@ spec:
         - name: Sitecore__InstanceUri
           value: http://cd
         - name: Sitecore__RenderingHostUri
-          value: https://$(STAGING_HOST)/
+          value: https://mvp.sitecoredemo.com/
         - name: Sitecore__EnableExperienceEditor
           value: "true"
         - name: Sitecore_License


### PR DESCRIPTION
Init containers were causing issues when run against existing DB's, changed Azure pipeline to no longer delete old jobs. If the jobs exist they will be skipped.

Renamed rendering container to mvp-rendering to match local development and remove need for transform on name.
