### PR TITLE
Commended out Init Tasks from staging deploy

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -160,20 +160,20 @@ stages:
               kubernetesServiceConnection: '$(AKS_SERVICE_ENDPOINT)'
               namespace: 'mvp-staging'
               manifests: '$(bake_external.manifestsBundle)'
-          - task: KubernetesManifest@0
-            displayName: Bake Init Specifications
-            name: 'bake_init'
-            inputs:
-              action: 'bake'
-              renderType: 'kustomize'
-              kustomizationPath: '$(System.ArtifactsDirectory)/k8s-specs/init/'
-          - task: KubernetesManifest@0
-            displayName: Deploy Init Specifications
-            inputs:
-              action: 'deploy'
-              kubernetesServiceConnection: '$(AKS_SERVICE_ENDPOINT)'
-              namespace: 'mvp-staging'
-              manifests: '$(bake_init.manifestsBundle)'
+          # - task: KubernetesManifest@0
+          #   displayName: Bake Init Specifications
+          #   name: 'bake_init'
+          #   inputs:
+          #     action: 'bake'
+          #     renderType: 'kustomize'
+          #     kustomizationPath: '$(System.ArtifactsDirectory)/k8s-specs/init/'
+          # - task: KubernetesManifest@0
+          #   displayName: Deploy Init Specifications
+          #   inputs:
+          #     action: 'deploy'
+          #     kubernetesServiceConnection: '$(AKS_SERVICE_ENDPOINT)'
+          #     namespace: 'mvp-staging'
+          #     manifests: '$(bake_init.manifestsBundle)'
           - task: KubernetesManifest@0
             displayName: Bake Application Specifications
             name: 'bake_application'


### PR DESCRIPTION
Init specs only need to be applied once per environment as they will "reset" the database and remove any author edits.

The tasks to run the init specs has been commented out in the azure-devops.yaml definition. I left it in so people have an example of how to run them if they need to.