### PR TITLE
Added config to enable export of SPE reports

### DIFF
--- a/src/Environment/sitecore/App_Config/Include/z_SPE/Spe.IdentityServer.config
+++ b/src/Environment/sitecore/App_Config/Include/z_SPE/Spe.IdentityServer.config
@@ -1,0 +1,23 @@
+﻿<!--
+	Sitecore PowerShell Extensions
+
+	This file enables the Console to work with authentication in Sitecore 9.1 and above.
+
+	This file should not be enabled on versions of Sitecore prior to 9.1.
+
+	http://github.com/kamsar/Unicorn
+-->
+<configuration xmlns:patch="http://www.sitecore.net/xmlconfig/" xmlns:role="http://www.sitecore.net/xmlconfig/role/" xmlns:security="http://www.sitecore.net/xmlconfig/security/">
+	<sitecore role:require="Standalone or ContentManagement" security:require="Sitecore">
+		<pipelines>
+			<owin.cookieAuthentication.validateIdentity>
+				<processor type="Sitecore.Owin.Authentication.Pipelines.CookieAuthentication.ValidateIdentity.ValidateSiteNeutralPaths, Sitecore.Owin.Authentication">
+					<siteNeutralPaths hint="list">
+						<!-- This entry corrects the infinite loop of ExecuteCommand in the SPE Console -->
+						<path hint="spe">/sitecore%20modules/PowerShell</path>
+					</siteNeutralPaths>
+				</processor>
+			</owin.cookieAuthentication.validateIdentity>
+		</pipelines>
+	</sitecore>
+</configuration>


### PR DESCRIPTION
Enabled `Spe.IdentityServer.config` configuration to allow for export of reports from SPE