### PR TITLE
Added conditional logic for UseHttpsRedirection, re-enabled liveness …

### DIFF
--- a/k8s/specs/staging/mvp-rendering.yaml
+++ b/k8s/specs/staging/mvp-rendering.yaml
@@ -90,15 +90,15 @@ spec:
               key: application_user_domain.txt
         - name: Application_CMS_URL
           value: http://cm
-        # livenessProbe:
-        #   httpGet:
-        #     path: /healthz
-        #     port: 443
-        #     httpHeaders:
-        #     - name: X-Kubernetes-Probe
-        #       value: Liveness           
-        #   timeoutSeconds: 60
-        #   periodSeconds: 30
-        #   failureThreshold: 3
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 443
+            httpHeaders:
+            - name: X-Kubernetes-Probe
+              value: Liveness           
+          timeoutSeconds: 60
+          periodSeconds: 30
+          failureThreshold: 3
       imagePullSecrets:
       - name: regcred

--- a/src/Project/MvpSite/rendering/Startup.cs
+++ b/src/Project/MvpSite/rendering/Startup.cs
@@ -141,7 +141,10 @@ namespace Mvp.Project.MvpSite.Rendering
                 app.UseExceptionHandler("/Error");
                 // The default HSTS value is 30 days. You may want to change this for production scenarios, see https://aka.ms/aspnetcore-hsts.
                 app.UseHsts();
-                app.UseHttpsRedirection();
+
+                //Add HTTPS redirection, but ignore for healthz path to allow for liveness probes over http
+                app.UseWhen(context => !context.Request.Path.StartsWithSegments("/healthz"),
+                    builder => builder.UseHttpsRedirection());
             }
 
             //Add recirects for old mvp pages


### PR DESCRIPTION
Added conditiional logic for `UseHttpsRedirection`, this will fire for all paths except for `/healthz` to allow for liveness probes to operate over HTTP.

Renabled Liveness probe for staging to test conditional logic above.