### PR TITLE
Split out staging cm ingress & applied upstream hashing. Increased st…

### DIFF
--- a/k8s/specs/staging/cm.yaml
+++ b/k8s/specs/staging/cm.yaml
@@ -16,7 +16,7 @@ metadata:
   labels:
     app: cm
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app: cm

--- a/k8s/specs/staging/ingress-nginx/ingress-with-hashing.yaml
+++ b/k8s/specs/staging/ingress-nginx/ingress-with-hashing.yaml
@@ -1,7 +1,7 @@
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: mvp-ingress
+  name: mvp-ingress-upstream-hash
   annotations:
     nginx.ingress.kubernetes.io/proxy-buffer-size: "32k"
     nginx.ingress.kubernetes.io/affinity: "cookie"
@@ -13,33 +13,17 @@ metadata:
     kubernetes.io/ingress.class: "nginx"
     nginx.ingress.kubernetes.io/server-snippet: |-
       add_header X-Robots-Tag "noindex, nofollow";
+    nginx.ingress.kubernetes.io/upstream-hash-by: "$request_uri"
 spec:
   rules:
-  - host: $(STAGING_CD_HOST)
+  - host: $(STAGING_CM_HOST)
     http:
       paths:
       - path: /
         backend:
-          serviceName: cd
+          serviceName: cm
           servicePort: 80
-  - host: $(STAGING_ID_HOST)
-    http:
-      paths:
-      - path: /
-        backend:
-          serviceName: id
-          servicePort: 80
-  - host: $(STAGING_HOST)
-    http:
-      paths:
-      - path: /
-        backend:
-          serviceName: mvp-rendering
-          servicePort: 80
-
   tls:
   - secretName: sitecoredemo-tls
     hosts:
-    - $(STAGING_HOST)
-    - $(STAGING_ID_HOST)
-    - $(STAGING_CD_HOST)
+    - $(STAGING_CM_HOST)

--- a/k8s/specs/staging/ingress-nginx/kustomization.yaml
+++ b/k8s/specs/staging/ingress-nginx/kustomization.yaml
@@ -2,4 +2,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
+  - ingress-with-hashing.yaml
   - ingress.yaml


### PR DESCRIPTION
Split Staging Ingress into two definitions. CM now has `nginx.ingress.kubernetes.io/upstream-hash-by` annotation to enable sticky sessions.