### PR TITLE
Updated k8s image reference to id6, reduced cm replicas to 1 again

### DIFF
--- a/k8s/specs/prod/cm.yaml
+++ b/k8s/specs/prod/cm.yaml
@@ -27,7 +27,7 @@ metadata:
   labels:
     app: cm
 spec:
-  replicas: 2
+  replicas: 1
   selector:
     matchLabels:
       app: cm

--- a/k8s/specs/prod/kustomization.yaml
+++ b/k8s/specs/prod/kustomization.yaml
@@ -8,7 +8,7 @@ images:
   newName: $(ACR_ENDPOINT)/mvp-cm
   newTag: $(Build.BuildNumber)-$(Build.SourceBranchName)
 - name: sitecore-mvp-id
-  newName: $(ACR_ENDPOINT)/mvp-id
+  newName: $(ACR_ENDPOINT)/mvp-id6
   newTag: $(Build.BuildNumber)-$(Build.SourceBranchName)
 - name: sitecore-mvp-rendering
   newName: $(ACR_ENDPOINT)/mvp-rendering

--- a/k8s/specs/staging/cm.yaml
+++ b/k8s/specs/staging/cm.yaml
@@ -27,7 +27,7 @@ metadata:
   labels:
     app: cm
 spec:
-  replicas: 2
+  replicas: 1
   selector:
     matchLabels:
       app: cm

--- a/k8s/specs/staging/kustomization.yaml
+++ b/k8s/specs/staging/kustomization.yaml
@@ -8,7 +8,7 @@ images:
   newName: $(ACR_ENDPOINT)/mvp-cm
   newTag: $(Build.BuildNumber)-$(Build.SourceBranchName)
 - name: sitecore-mvp-id
-  newName: $(ACR_ENDPOINT)/mvp-id
+  newName: $(ACR_ENDPOINT)/mvp-id6
   newTag: $(Build.BuildNumber)-$(Build.SourceBranchName)
 - name: sitecore-mvp-rendering
   newName: $(ACR_ENDPOINT)/mvp-rendering


### PR DESCRIPTION
Small changes to update k8s specs ready for 10.2 upgrade

Reduced CM replica count back to 1 due to MVP application process not working with scaled instances.