### PR TITLE
Updated READNE.md to clarify how OKTA_DOMAIN must be specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The Sitecore MVP site is an Open Source project and as such we welcome community
     ```
 
 3. At the bottom of the `.env` file you'll find the section for your Okta developer account details. You will need to populate the following values:
-   - OKTA_DOMAIN
+   - OKTA_DOMAIN (*must* include protocol, e.g. `OKTA_DOMAIN=https://dev-your-id.okta.com`)
    - OKTA_CLIENT_ID
    - OKTA_CLIENT_SECRET
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Updated README.md to clarify that `https` has to be included in the OCTA_DOMAIN variable or container startup will fail rather cryptically

## Description
Updated README.md

## Motivation
<!--- Why is this change required? What problem does it solve? -->
To not mystify developers who just paste in the DOMAIN from the OKTA settings page

## How Has This Been Tested?
Not at all

## Types of changes
Documentation update

## Checklist:
All good
