### PR TITLE
Fix directory sortorder

### DIFF
--- a/src/Foundation/People/platform/ComputedFields/PersonFullName.cs
+++ b/src/Foundation/People/platform/ComputedFields/PersonFullName.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Web;
 using Sitecore.Data.Items;
+using System.Globalization;
 
 namespace Mvp.Foundation.People.ComputedFields
 {
@@ -15,7 +16,8 @@ namespace Mvp.Foundation.People.ComputedFields
             Item item = (Item)(indexable as SitecoreIndexableItem);
             if (item != null && item.TemplateID.Equals(Constants.Templates.Person))
             {
-                return item["First Name"] + item["Last Name"];
+                var personFullNameSimple = item["First Name"] + " " + item["Last Name"];
+                return CultureInfo.CurrentCulture.TextInfo.ToTitleCase(personFullNameSimple);
             }
             return false;
         }


### PR DESCRIPTION
Fix directory sort order by making PersonFullName in format TitleCase

## Description
Change the computed field PersonFullName in format TitleCase to help the SolR sort order.
The computed field PersonFullName is used only for the sort order.

## Motivation
Some first and last names on people are in lowercase so when sorted those will show up at the end of the list.

![2022-02-02_15h55_42](https://user-images.githubusercontent.com/1449681/152167729-4a8181f0-fe08-445b-8631-ec163d570e04.png)


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (non-breaking change; modified files are limited to the `/docs` directory)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the Contributing guide.
- [x] My code follows the code style of this project.
- [x] My code/comments/docs fully adhere to the Code of Conduct.
- [ ] My change is a code change and it requires an update to the documentation.
- [ ] My change is a documentation change and it requires an update to the navigation.

## _Please make sure to re-index sitecore_master_index and sitecore_web_index to make sure that the new computed field is indexed when things are deployed_