### PR TITLE
Making the MVP' email  case-insensitive so that gravatar images are p…

### DIFF
--- a/src/Foundation/People/rendering/Extensions/GravatarExtensions.cs
+++ b/src/Foundation/People/rendering/Extensions/GravatarExtensions.cs
@@ -14,7 +14,7 @@ namespace Mvp.Foundation.People.Extensions
         {
             var result = string.Format("{0}://gravatar.com/avatar/{1}?s={2}{3}",
                                "https",
-                               GetMd5Hash(email),
+                               GetMd5Hash(email.ToLowerInvariant()),
                                ImageSize,
                                "&d=" + (!string.IsNullOrEmpty(DefaultImageUrl) ? HtmlEncoder.Default.Encode(DefaultImageUrl) : DefaultImage.Default.GetDescription())
                            );

--- a/src/Foundation/User/rendering/Extensions/GravatarHtmlHelper.cs
+++ b/src/Foundation/User/rendering/Extensions/GravatarHtmlHelper.cs
@@ -100,7 +100,7 @@ namespace Mvp.Foundation.User.Extensions
                 string.Format("{0}://{1}.gravatar.com/avatar/{2}?s={3}{4}{5}{6}",
                     htmlHelper.ViewContext.HttpContext.Request.IsHttps || forceSecureRequest ? "https" : "http",
                     htmlHelper.ViewContext.HttpContext.Request.IsHttps || forceSecureRequest ? "secure" : "www",
-                    GetMd5Hash(emailAddress),
+                    GetMd5Hash(emailAddress.ToLowerInvariant()),
                     size.ToString(),
                     "&d=" + (!string.IsNullOrEmpty(defaultImageUrl) ? htmlHelper.UrlEncoder.Encode(defaultImageUrl) : defaultImage.GetDescription()),
                     forceDefaultImage ? "&f=y" : "",
@@ -127,7 +127,7 @@ namespace Mvp.Foundation.User.Extensions
         {
 
             // Convert the input string to a byte array and compute the hash.
-            byte[] data = MD5.Create().ComputeHash(Encoding.UTF8.GetBytes(input.ToLowerInvariant()));
+            byte[] data = MD5.Create().ComputeHash(Encoding.UTF8.GetBytes(input));
 
             // Create a new Stringbuilder to collect the bytes
             // and create a string.

--- a/src/Foundation/User/rendering/Extensions/GravatarHtmlHelper.cs
+++ b/src/Foundation/User/rendering/Extensions/GravatarHtmlHelper.cs
@@ -127,7 +127,7 @@ namespace Mvp.Foundation.User.Extensions
         {
 
             // Convert the input string to a byte array and compute the hash.
-            byte[] data = MD5.Create().ComputeHash(Encoding.UTF8.GetBytes(input));
+            byte[] data = MD5.Create().ComputeHash(Encoding.UTF8.GetBytes(input.ToLowerInvariant()));
 
             // Create a new Stringbuilder to collect the bytes
             // and create a string.


### PR DESCRIPTION
Makes the email address case agnostic so that gravatar profile is picked automagically

## Description
Email address not in lower case get hashed improperly. So, necessary to make the email case agnostic.

https://navansitecorenotes.blogspot.com/2022/02/gravatar-profile-for-sitecore-mvp-site.html

## Motivation
My email wasn't picked up since it seems to have been stored with capital  C while gravatar is looking at a hash generated from lower case. My email had to be adjusted in the back-end manually but now, this change will save the MVP website from such issues in future

## How Has This Been Tested?
Through a console application that isolates the issue

https://navansitecorenotes.blogspot.com/2022/03/making-sitecore-mvp-email-address-case.html

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (non-breaking change; modified files are limited to the `/docs` directory)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] I have read the Contributing guide.
- [x ] My code follows the code style of this project.
- [x ] My code/comments/docs fully adhere to the Code of Conduct.
- [ ] My change is a code change and it requires an update to the documentation.
- [ ] My change is a documentation change and it requires an update to the navigation.
