### PR TITLE
updated gitignore to remove .env causing AzureDevops builds to fail

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,6 @@
 *.user
 *.userosscache
 *.sln.docstates
-.env
 
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs


### PR DESCRIPTION
Fix to issue with start-env causing Azure-Devops to fail with missing env vars