### PR TITLE
update memory settings for rendering host

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -57,7 +57,7 @@ services:
       Application_User_Password: ${SITECORE_APPLICATION_USER_PASSWORD}
       Application_User_Domain: ${SITECORE_APPLICATION_USER_DOMAIIN}
       Application_CMS_URL: ${SITECORE_Application_CMS_URL}
-    mem_limit: ${MEM_LIMIT_RENDERING:-1GB}           
+    mem_limit: ${MEM_LIMIT_RENDERING:-2GB}           
     depends_on:
       - solutionBuildOutput
       - cm

--- a/docker-compose.sugcon.yml
+++ b/docker-compose.sugcon.yml
@@ -34,7 +34,7 @@ services:
       Application_CMS_URL: ${SITECORE_Application_CMS_URL}
     ports:
       - "80"      
-    mem_limit: ${MEM_LIMIT_RENDERING:-1GB}           
+    mem_limit: ${MEM_LIMIT_RENDERING:-2GB}           
     depends_on:
       - sugcon-rendering
       - cm


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Update memory limits for rendering host.

## Motivation
While setting up mvp-site, were getting below error.

```
error for mvp-rendering cannot start service mvp-rendering :  hcsshim: createcompuresystem XXXX : the request is in use.
error for sugcon-eu-rendering cannot start service sugcon-eu-rendering :  hcsshim: createcompuresystem XXXX : the request is in use.
```

## How Has This Been Tested?
after adjusting the memory limit, followed the same steps what is mentioned in installation steps, i was able to see Sitecore interface and both websites.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (non-breaking change; modified files are limited to the `/docs` directory)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the Contributing guide.
- [x] My code follows the code style of this project.
- [x] My code/comments/docs fully adhere to the Code of Conduct.
- [x] My change is a code change and it requires an update to the documentation.
- [ ] My change is a documentation change and it requires an update to the navigation.
